### PR TITLE
Test nf-core download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+nf-core-rnaseq_3.12.0/
+singularity-images/

--- a/README.md
+++ b/README.md
@@ -21,16 +21,37 @@ Provide instructions on how to use the repository for your project. For example:
 
 ## Environment set up 
 
-Brief summary of what environment you're working in, any dependencies, installation, configuration required. 
-
 ### Compute environment 
 
-Set up instructions relevant to the compute platform. 
+All testing for this workshop is being performed on Pawsey's Nimbus cloud. VMs are 2c.8r with 40Gb of disk. To create an instance:
+
+* Open Nimbus dashboard 
+* Navigate to rnaseq-workshop project in the top menu drop down 
+* Add the 8787 network port for Rstudio (this was done for whole project)
+    * In side menu go to Network > Security Group
+    * Follow instructions [here](https://support.pawsey.org.au/documentation/display/US/Run+RStudio+Interactively#)
+* Create an instance 
+    * In side menu go to Compute > Instances > Launch Instance
+    * Provide a name for the instance 
+    * Source: Pawsey Bio - Ubuntu 22.04 - 2023-06
+    * Flavour: n3.2c8r
+    * Networks: Public external
+    * Security Groups: port 8787, rnaseq-workshop-SSH-ICMP
+    * Keypair: either specify existing or make a new one and save to your local machine
+    * Launch instance
 
 ### Test data 
 
-Description of test datasets, where/how to access them. 
+Testing with 2022 rnaseq workshop material on CVMFS. To access from the Nimbus CLI: 
+
+```bash
+ls /cvmfs/data.biocommons.aarnet.edu.au/training_materials/SIH_training/IntroRNAseq_0922/
+```
+
+* You will need to cache with (ls) before trying to use the files 
+* You cannot cd into CVMFS, it is read-only
 
 ## External resources 
 
-Links to resources consulted for this project. 
+* [nf-core/rnaseq](https://github.com/nf-core/rnaseq/tree/3.12.0)
+* [nf-core/tools](https://nf-co.re/tools)

--- a/Scripts/Day1/README.md
+++ b/Scripts/Day1/README.md
@@ -1,0 +1,64 @@
+# Testing runtime of nf-core/rnaseq 
+
+## Use of nf-core tools for downloading code base and containers 
+
+1. [Install nf-core tools](https://nf-co.re/tools#installation) with pip (not conda)
+```bash
+sudo pip install nf-core
+```
+
+Test download by printing help message 
+```bash
+nf-core -h
+```
+
+2. [Download pipeline code base with containers](https://nf-co.re/tools#downloading-pipelines-for-offline-use)
+
+```bash
+time nf-core download 
+```
+Used prompts to download:
+* rnaseq 
+* version 3.12.0
+* use singularity containers 
+* container library quay.io
+* institutional configs true
+* output directory: nf-core-rnaseq_3.12.0
+
+**Time taken**
+* real    31m34.944s
+* user    2m10.827s
+* sys     0m21.961s
+
+What is the command for this without prompts? 
+
+```bash
+nf-core download nf-core/rnaseq \
+    --revision 3.12.0 \
+    --container singularity \
+    --compress none
+```
+
+3. [Download pipeline code base without containers](https://nf-co.re/tools#downloading-pipelines-for-offline-use)
+
+```bash
+NXF_SINGULARITY_CACHEDIR=/home/ubuntu/rnaseqOct23_Testing/singularity-images
+
+echo $NXF_SINGULARITY_CACHEDIR
+
+nf-core download nf-core/rnaseq \
+    --revision 3.12.0 \
+    --container singularity \
+    --compress none \
+    --singularity-cache-only
+```
+
+* Had to copy containers to workflow directory, need to check if this can be skipped or avoided 
+* This makes a copy of the singularity images, rather than symlink???? 
+
+**Time taken**
+* real    1m45.437s
+* user    0m6.106s
+* sys     0m3.185s
+
+Using a specified singularity cache (`$NXF_SINGULARITY_CACHEDIR`) available on all cloned VMs, we can reduce download time. 

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,0 +1,4 @@
+## Code and scripts used for testing 
+
+* Day 1 contains nf-core related testing 
+* Day 2 contains Rstudio related testing


### PR DESCRIPTION
Closes #1 

Found that pulling of containers is very time consuming. Will set up VMs to have containers pre-downloaded. Users will just need to specify cache. 

